### PR TITLE
Fix for line breaks between block labels

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -663,20 +663,12 @@ func marshalBlock(w io.Writer, indent string, block *Block) error {
 	if block.Repeated {
 		fmt.Fprint(w, "(repeated)")
 	}
-	labelIndent := len(prefix)
-	size := labelIndent
-	for i, label := range block.Labels {
+	for _, label := range block.Labels {
 		text := label
 		if needsQuote.MatchString(label) {
 			text = strconv.Quote(label)
 		}
-		size += len(text)
-		if i > 0 && size+2 >= 80 {
-			size = labelIndent
-			fmt.Fprintf(w, "\n %s", strings.Repeat(" ", labelIndent))
-		} else {
-			fmt.Fprintf(w, " ")
-		}
+		fmt.Fprintf(w, " ")
 		fmt.Fprintf(w, "%s", text)
 	}
 	fmt.Fprintln(w, " {")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -128,8 +128,7 @@ block multiple labels varargs {
 				},
 			},
 			expected: `
-block multiple labels var-args really "really is" really really long labels that are
-      really long {
+block multiple labels var-args really "really is" really really long labels that are really long {
 }
 `,
 		},


### PR DESCRIPTION
Fix for line breaks between block labels which breaks Terraform HCL parsing.

```
╷
│ Error: Missing name for resource
│
│   on main.tf line 1:
│    1: resource "google_compute_global_address"
│
│ All resource blocks must have 2 labels (type, name).
╵
╷
│ Error: Invalid block definition
│
│   on main.tf line 1:
│    1: resource "google_compute_global_address"
│    2:          "very-long-label-here-that-making-the-line-exceed-80-chars" {
│
│ A block definition must have block content delimited by "{" and "}", starting on the same line as the
│ block header.
╵
```